### PR TITLE
🏷️ Improve annotation on the asyncapi module

### DIFF
--- a/fastapi_asyncapi/asyncapi.py
+++ b/fastapi_asyncapi/asyncapi.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from typing import Any, Dict, List, Literal, Optional, Sequence, cast
 
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
@@ -12,11 +12,12 @@ from fastapi_asyncapi.schema import (
     ChannelItem,
     Channels,
     Contact,
+    HTTPMethod,
     HTTPOperationBinding,
     Info,
     License,
+    Operation,
     Server,
-    Subscribe,
     Tag,
     WSOperationBinding,
 )
@@ -34,7 +35,7 @@ def get_asyncapi(
     contact: Optional[Contact] = None,
     license: Optional[License] = None,
     tags: Optional[List[Tag]] = None,
-    servers: Optional[List[Server]] = None,
+    servers: Optional[Dict[str, Server]] = None,
 ) -> Dict[str, Any]:
     info = Info(
         title=title,
@@ -50,11 +51,11 @@ def get_asyncapi(
             channel = ChannelItem(
                 ref=route.path,
                 description=route.description,
-                subscribe=Subscribe(
+                subscribe=Operation(
                     operationId=route.unique_id,
                     bindings=Bindings(
                         http=HTTPOperationBinding(
-                            type="request", method=next(iter(route.methods))
+                            type="request", method=cast(HTTPMethod, min(route.methods))
                         )
                     ),
                 ),
@@ -63,7 +64,7 @@ def get_asyncapi(
         elif isinstance(route, APIWebSocketRoute):
             channel = ChannelItem(
                 ref=route.path,
-                subscribe=Subscribe(
+                subscribe=Operation(
                     operationId=route.name,  # TODO: Create the same `unique_id`.
                     bindings=Bindings(ws=WSOperationBinding()),
                 ),

--- a/fastapi_asyncapi/schema.py
+++ b/fastapi_asyncapi/schema.py
@@ -170,20 +170,20 @@ MessagesTraits = List[MessageTrait]
 
 
 class Message(BaseModel):
-    headers: Optional[Union[Schema, Reference]]
-    payload: Optional[Any]
-    correlationId: Optional[Union[CorrelationID, Reference]]
-    schemaFormat: Optional[str]
-    contentType: Optional[str]
-    name: Optional[str]
-    title: Optional[str]
-    summary: Optional[str]
-    description: Optional[str]
-    tags: Optional[List[Tag]]
-    externalDocs: Optional[ExternalDocumentation]
-    bindings: Optional[MessageBinding]
-    examples: Optional[ExamplesMessages]
-    traits: Optional[MessagesTraits]
+    headers: Optional[Union[Schema, Reference]] = None
+    payload: Optional[Any] = None
+    correlationId: Optional[Union[CorrelationID, Reference]] = None
+    schemaFormat: Optional[str] = None
+    contentType: Optional[str] = None
+    name: Optional[str] = None
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    tags: Optional[List[Tag]] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+    bindings: Optional[MessageBinding] = None
+    examples: Optional[ExamplesMessages] = None
+    traits: Optional[MessagesTraits] = None
 
 
 class Operation(BaseModel):
@@ -195,10 +195,6 @@ class Operation(BaseModel):
     bindings: Optional[Bindings] = None
     traits: Optional[OperationTraits] = None
     message: Optional[Message] = None
-
-
-Subscribe = Operation
-Publish = Operation
 
 
 class Parameter(BaseModel):
@@ -217,13 +213,10 @@ class ChannelItem(BaseModel):
     ref: Optional[str] = Field(default=None, alias="$ref")
     description: Optional[str] = None
     servers: Optional[List[str]] = None
-    subscribe: Optional[Subscribe] = None
-    publish: Optional[Publish] = None
+    subscribe: Optional[Operation] = None
+    publish: Optional[Operation] = None
     parameters: Optional[Parameters] = None
     bindings: Optional[Union[ChannelBindings, Reference]] = None
-
-    # class Config:
-    #     allow_population_by_field_name = True
 
 
 Security = Dict[str, List[str]]
@@ -309,16 +302,19 @@ class Components(BaseModel):
         extra = "allow"
 
 
+Identifier = str
+
+
 class AsyncAPI(BaseModel):
     asyncapi: str
-    id: Optional[str]
+    id: Optional[Identifier]
     info: Info
-    servers: Optional[Dict[str, Server]]
-    defaultContentType: Optional[str]
+    servers: Optional[Dict[str, Server]] = None
+    defaultContentType: str = "application/json"
     channels: Channels
-    components: Optional[Components]
+    components: Optional[Components] = None
     tags: Optional[List[Tag]]
-    externalDocs: Optional[ExternalDocumentation]
+    externalDocs: Optional[ExternalDocumentation] = None
 
     # @root_validator(pre=True)
     # def validate_security(cls, values):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, WebSocket
+from fastapi.responses import JSONResponse
 from pydantic import AnyHttpUrl
 
 from fastapi_asyncapi import get_asyncapi, get_asyncapi_html
@@ -8,7 +9,10 @@ app = FastAPI(title="MyAPI", version="1.0.0", docs_url=None)
 
 @app.get("/asyncapi.json")
 async def asyncapi_json():
-    return get_asyncapi(title=app.title, version=app.version, routes=app.routes)
+    return JSONResponse(
+        get_asyncapi(title=app.title, version=app.version, routes=app.routes),
+        media_type="application/vnd.aai.asyncapi+json;version=2.4.0",
+    )
 
 
 @app.get("/docs")

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -31,6 +31,8 @@ async def websocket_endpoint(websocket: WebSocket):
 
 def test_application():
     schema = get_asyncapi(title=app.title, version=app.version, routes=app.routes)
+    # import json
+
     # print(json.dumps(schema, indent=4, sort_keys=True))
     assert schema == {
         "asyncapi": "2.4.0",
@@ -68,5 +70,6 @@ def test_application():
                 }
             },
         },
+        "defaultContentType": "application/json",
         "info": {"title": "MyAPI", "version": "1.0.0"},
     }


### PR DESCRIPTION
## Changes
- Add `application/vnd.aai.asyncapi+json;version=2.4.0` media type on the `/asyncapi.json` endpoint. - I'm not sure if it's necessary, in case it's not, I'll remove that logic.
<img width="703" alt="image" src="https://user-images.githubusercontent.com/7353520/170559730-5e6da26e-daa1-45a4-a8f2-c7bf6dbf97ea.png">

